### PR TITLE
include missing packages at setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,9 @@ setup(
         'jieba',
         'embeddings',
         'quadprog',
-        'pyyaml'
+        'pyyaml',
+        'fuzzywuzzy',
+        'python-Levenshtein'
     ],
     extras_require={
         'develop': [


### PR DESCRIPTION
**Description:**
Added packages **`fuzzywuzzy`** and ** `python-Levenshtein`** to **`setup.py`**.
The second package is due to Warnings when using **`fuzzywuzzy`**

![warning](https://user-images.githubusercontent.com/18452584/92238804-56f7c080-ee90-11ea-926f-0d9158165372.png)

**Reference Issues:** #101 
