### PR TITLE
multiwoz dbquery doesnt require mutable constraints

### DIFF
--- a/convlab2/util/multiwoz/dbquery.py
+++ b/convlab2/util/multiwoz/dbquery.py
@@ -39,9 +39,7 @@ class Database(object):
                 return deepcopy(self.dbs['hospital'])
             else:
                 return [deepcopy(x) for x in self.dbs['hospital'] if x['department'].lower() == department.strip().lower()]
-        for ele in constraints:
-            if ele[0] == 'area' and ele[1] == 'center':
-                ele[1] = 'centre'
+        constraints = list(map(lambda ele: ele if not(ele[0] == 'area' and ele[1] == 'center') else ('area', 'centre'), constraints))
 
         found = []
         for i, record in enumerate(self.dbs[domain]):


### PR DESCRIPTION
**Description:**

`util/multiwoz/dbquery.py:42`
The `query()` method expects elements of the constraints argument to be mutable.
However, tuples are used as the elements and given to the method call in the ConvLab code `MultiWozEvaluator._final_goal_analyze()`.

**Reference Issues:** #XX (XX is the issue number you work on)
#105 