### PR TITLE
Fix bug for can't generate correct vectorized state

### DIFF
--- a/convlab2/policy/mle/crosswoz/loader.py
+++ b/convlab2/policy/mle/crosswoz/loader.py
@@ -45,6 +45,7 @@ class PolicyDataLoaderCrossWoz():
                 dst.init_session()
                 for i, turn in enumerate(sess):
                     if turn['role'] == 'usr':
+                        dst.state['user_action'] = turn['dialog_act']
                         dst.update(usr_da=turn['dialog_act'])
                         if i + 2 == len(sess):
                             dst.state['terminated'] = True


### PR DESCRIPTION
dst.update don't update dst.state['user_action'], so dst.state['user_action'] is always empty, The following function state_vectorize cannot get the correct user_action.  sr_act_vec is always zero.
