### PR TITLE
fix reset to make user talk first

### DIFF
--- a/convlab2/dialog_agent/env.py
+++ b/convlab2/dialog_agent/env.py
@@ -19,6 +19,7 @@ class Environment():
         self.sys_dst.init_session()
         if self.evaluator:
             self.evaluator.add_goal(self.usr.policy.get_goal())
+        s, r, t = self.step([])
         return self.sys_dst.state
         
     def step(self, action):


### PR DESCRIPTION
**Description:** fix the problem that the system talks first for policy training in multiwoz



**Reference Issues:** #167 