### PR TITLE
update get_reward

### DIFF
--- a/convlab2/dialog_agent/env.py
+++ b/convlab2/dialog_agent/env.py
@@ -33,12 +33,7 @@ class Environment():
         state = self.sys_dst.update(dialog_act)
         
         if self.evaluator:
-            if self.evaluator.task_success():
-                reward = 40
-            elif self.evaluator.cur_domain and self.evaluator.domain_success(self.evaluator.cur_domain):
-                reward = 5
-            else:
-                reward = -1
+            reward = self.evaluator.get_reward()
         else:
             reward = self.usr.get_reward()
         terminated = self.usr.is_terminated()

--- a/convlab2/dialog_agent/session.py
+++ b/convlab2/dialog_agent/session.py
@@ -126,7 +126,7 @@ class BiSession(Session):
             # print('inform prec. {} rec. {} F1 {}'.format(prec, rec, f1))
             # print('book rate {}'.format(self.evaluator.book_rate()))
             # print('task success {}'.format(self.evaluator.task_success()))
-        reward = self.user_agent.get_reward()
+        reward = self.user_agent.get_reward() if self.evaluator is None else self.evaluator.get_reward()
         sys_response = self.next_response(user_response)
         self.dialog_history.append([self.user_agent.name, user_response])
         self.dialog_history.append([self.sys_agent.name, sys_response])

--- a/convlab2/evaluator/evaluator.py
+++ b/convlab2/evaluator/evaluator.py
@@ -55,3 +55,6 @@ class Evaluator(object):
     def final_goal_analyze(self):
         """judge whether the final goal satisfies the database constraints"""
         raise NotImplementedError
+
+    def get_reward(self):
+        raise NotImplementedError

--- a/convlab2/evaluator/evaluator.py
+++ b/convlab2/evaluator/evaluator.py
@@ -57,4 +57,5 @@ class Evaluator(object):
         raise NotImplementedError
 
     def get_reward(self):
+        """returns a reward, which can be used by RL training."""
         raise NotImplementedError

--- a/convlab2/evaluator/evaluator.py
+++ b/convlab2/evaluator/evaluator.py
@@ -57,5 +57,5 @@ class Evaluator(object):
         raise NotImplementedError
 
     def get_reward(self):
-        """returns a reward, which can be used by RL training."""
+        """returns a reward, which is used for RL training."""
         raise NotImplementedError

--- a/convlab2/evaluator/multiwoz_eval.py
+++ b/convlab2/evaluator/multiwoz_eval.py
@@ -415,7 +415,6 @@ class MultiWozEvaluator(Evaluator):
             return match / (match + mismatch)
 
     def get_reward(self):
-        """returns a reward, which can be used by RL training."""
         if self.task_success():
             reward = 40
         elif self.cur_domain and self.domain_success(self.cur_domain):

--- a/convlab2/evaluator/multiwoz_eval.py
+++ b/convlab2/evaluator/multiwoz_eval.py
@@ -413,3 +413,13 @@ class MultiWozEvaluator(Evaluator):
             return 1
         else:
             return match / (match + mismatch)
+
+    def get_reward(self):
+        """returns a reward, which can be used by RL training."""
+        if self.task_success():
+            reward = 40
+        elif self.cur_domain and self.domain_success(self.cur_domain):
+            reward = 5
+        else:
+            reward = -1
+        return reward


### PR DESCRIPTION
Rewards during training and testing were different (#195), although reward during testing is useless.
They are the same now: if evaluator is available, use `evaluator.get_reward()`; otherwise, use `user_simulator.get_reward()`