### PR TITLE
fix bug. tag_seq is cut, but word_seq is not cut

### DIFF
--- a/convlab2/nlu/jointBERT/multiwoz/postprocess.py
+++ b/convlab2/nlu/jointBERT/multiwoz/postprocess.py
@@ -33,6 +33,7 @@ def calculateF1(predict_golden):
 
 
 def tag2triples(word_seq, tag_seq):
+    word_seq = word_seq[:len(tag_seq)]
     assert len(word_seq)==len(tag_seq)
     triples = []
     i = 0


### PR DESCRIPTION
* Bug description
if input text of BERT NLU is too long, it will be cut. As a result, tag_seq is also cut. But word_seq is the original input text.
