### PR TITLE
Update model url from Azure to Hugging Face

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ We perform end-to-end evaluation (1000 dialogues) on MultiWOZ using the user sim
 
 ```python
 # BERT nlu trained on sys utterance
-user_nlu = BERTNLU(mode='sys', config_file='multiwoz_sys_context.json', model_file='https://convlab.blob.core.windows.net/convlab-2/bert_multiwoz_sys_context.zip')
+user_nlu = BERTNLU(mode='sys', config_file='multiwoz_sys_context.json', model_file='https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/bert_multiwoz_sys_context.zip')
 user_dst = None
 user_policy = RulePolicy(character='usr')
 user_nlg = TemplateNLG(is_user=True)
@@ -238,8 +238,8 @@ Without modifying any code, you could:
 
 - for translation-train SUMBT model:
 
-  - [trained on CrossWOZ-en](https://convlab.blob.core.windows.net/convlab-2/crosswoz_en-pytorch_model.bin.zip)
-  - [trained on MultiWOZ-zh](https://convlab.blob.core.windows.net/convlab-2/multiwoz_zh-pytorch_model.bin.zip)
+  - [trained on CrossWOZ-en](https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/crosswoz_en-pytorch_model.bin.zip)
+  - [trained on MultiWOZ-zh](https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/multiwoz_zh-pytorch_model.bin.zip)
   - Say the data set is CrossWOZ (English), (after extraction) just save the pre-trained model under `./convlab2/dst/sumbt/crosswoz_en/pre-trained` and name it with `pytorch_model.bin`. 
 
 ## Issues

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@
 
 ## Updates
 
-2022.10.30:
+2022.11.14:
 
-- Due to the potential security risk, The trained models of ConvLab-2 hosted at Azure can not be accessed currently. Therefore, we copied these models and placed them in [Hugging Face](https://huggingface.co/ConvLab/ConvLab-2_models). If you try to use trained models of ConvLab-2, you need to replace the model URL in the ConvLab-2 code with the model URL in our Hugging Face repo (the suffix should be the same).
+- Due to the potential security risk, The trained models of ConvLab-2 hosted at Azure can not be accessed currently. Therefore, we copied these models and placed them in [Hugging Face](https://huggingface.co/ConvLab/ConvLab-2_models). We've replaced the model URL in the ConvLab-2 code with the model URL in our Hugging Face repo. If you try to use trained models of ConvLab-2, make sure to update the code.
 
 2021.9.13:
 

--- a/convlab2/dst/comer/multiwoz/comer.py
+++ b/convlab2/dst/comer/multiwoz/comer.py
@@ -44,8 +44,8 @@ def revert_state(model_output:dict, reversed_vocab:dict):
 
 
 class ComerTracker(DST):
-    def __init__(self, model_file='https://convlab.blob.core.windows.net/convlab-2/comer.zip',
-                 embed_file='https://convlab.blob.core.windows.net/convlab-2/comer_embed.zip'):
+    def __init__(self, model_file='https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/comer.zip',
+                 embed_file='https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/comer_embed.zip'):
         super().__init__()
         parser = argparse.ArgumentParser(description='predict.py')
         parser.add_argument('-config', default='config.yaml', type=str,

--- a/convlab2/dst/comer/multiwoz/function.py
+++ b/convlab2/dst/comer/multiwoz/function.py
@@ -107,7 +107,7 @@ class ComerTracker(DST):
         self.state = None
         self.init_session()
 
-    def download_data(self, data_url="https://convlab.blob.core.windows.net/convlab-2/comer.zip"):
+    def download_data(self, data_url="https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/comer.zip"):
         """Automatically download the pretrained model and necessary data."""
         if os.path.exists(os.path.join(self.multiwoz_root, 'data/mwoz2_dm.dict')) and \
                 os.path.exists(os.path.join(self.multiwoz_root, 'data/mwoz2_sl.dict')) and \

--- a/convlab2/dst/sumbt/multiwoz/sumbt.py
+++ b/convlab2/dst/sumbt/multiwoz/sumbt.py
@@ -75,7 +75,7 @@ class SUMBTTracker(DST):
     """
 
 
-    def __init__(self, data_dir=DATA_PATH, model_file='https://convlab.blob.core.windows.net/convlab-2/sumbt.tar.gz', eval_slots=multiwoz_slot_list):
+    def __init__(self, data_dir=DATA_PATH, model_file='https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/sumbt.tar.gz', eval_slots=multiwoz_slot_list):
 
         DST.__init__(self)
 
@@ -153,7 +153,7 @@ class SUMBTTracker(DST):
         # model_file = os.path.join(DOWNLOAD_DIRECTORY, 'pytorch_model.zip')
 
         # if not os.path.isfile(model_file):
-        model_file = 'https://convlab.blob.core.windows.net/convlab-2/sumbt.tar.gz'
+        model_file = 'https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/sumbt.tar.gz'
 
         import tarfile
         if not os.path.isfile(os.path.join(DOWNLOAD_DIRECTORY, 'pytorch_model.bin')):

--- a/convlab2/dst/trade/crosswoz/trade.py
+++ b/convlab2/dst/trade/crosswoz/trade.py
@@ -108,7 +108,7 @@ class CrossWOZTRADE(TRADE, nn.Module):
     def init_session(self):
         self.state = default_state()
 
-    def download_model(self, model_url="https://convlab.blob.core.windows.net/convlab-2/trade_crosswoz_model.zip"):
+    def download_model(self, model_url="https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/trade_crosswoz_model.zip"):
         """Automatically download the pretrained model and necessary data."""
         if os.path.exists(os.path.join(self.crosswoz_root, 'model/TRADE-multiwozdst')):
             return
@@ -134,7 +134,7 @@ class CrossWOZTRADE(TRADE, nn.Module):
             print('unzipping model file ...')
             zip_ref.extractall(model_dir)
 
-    def download_data(self, data_url="https://convlab.blob.core.windows.net/convlab-2/trade_crosswoz_data.zip"):
+    def download_data(self, data_url="https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/trade_crosswoz_data.zip"):
         """Automatically download the pretrained model and necessary data."""
         if os.path.exists(os.path.join(self.crosswoz_root, 'data/crosswoz')) and \
                 os.path.exists(os.path.join(self.crosswoz_root, 'data/dev_dials.json')):

--- a/convlab2/dst/trade/crosswoz/train.py
+++ b/convlab2/dst/trade/crosswoz/train.py
@@ -16,7 +16,7 @@ python train.py
 '''
 
 
-def download_data(data_url="https://convlab.blob.core.windows.net/convlab-2/trade_crosswoz_data.zip"):
+def download_data(data_url="https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/trade_crosswoz_data.zip"):
     """Automatically download the pretrained model and necessary data."""
     crosswoz_root = os.path.dirname(os.path.abspath(__file__))
     if os.path.exists(os.path.join(crosswoz_root, 'data/crosswoz')) and \

--- a/convlab2/dst/trade/multiwoz/trade.py
+++ b/convlab2/dst/trade/multiwoz/trade.py
@@ -116,7 +116,7 @@ class MultiWOZTRADE(TRADE, nn.Module):
     def init_session(self):
         self.state = default_state()
 
-    def download_model(self, model_url="https://convlab.blob.core.windows.net/convlab-2/trade_multiwoz_model.zip"):
+    def download_model(self, model_url="https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/trade_multiwoz_model.zip"):
         """Automatically download the pretrained model and necessary data."""
         if os.path.exists(os.path.join(self.multiwoz_root, 'model/TRADE-multiwozdst')):
             return
@@ -143,7 +143,7 @@ class MultiWOZTRADE(TRADE, nn.Module):
             print('unzipping model file ...')
             zip_ref.extractall(model_dir)
 
-    def download_data(self, data_url="https://convlab.blob.core.windows.net/convlab-2/trade_multiwoz_data.zip"):
+    def download_data(self, data_url="https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/trade_multiwoz_data.zip"):
         """Automatically download the pretrained model and necessary data."""
         if os.path.exists(os.path.join(self.multiwoz_root, 'data/multi-woz')) and \
                 os.path.exists(os.path.join(self.multiwoz_root, 'data/dev_dials.json')):

--- a/convlab2/dst/trade/multiwoz/train.py
+++ b/convlab2/dst/trade/multiwoz/train.py
@@ -17,7 +17,7 @@ python train.py
 '''
 
 
-def download_data(data_url="https://convlab.blob.core.windows.net/convlab-2/trade_multiwoz_data.zip"):
+def download_data(data_url="https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/trade_multiwoz_data.zip"):
     """Automatically download the pretrained model and necessary data."""
     multiwoz_root = os.path.dirname(os.path.abspath(__file__))
     if os.path.exists(os.path.join(multiwoz_root, 'data/multi-woz')) and \

--- a/convlab2/e2e/damd/multiwoz/damd.py
+++ b/convlab2/e2e/damd/multiwoz/damd.py
@@ -16,8 +16,8 @@ from convlab2.e2e.damd.multiwoz.ontology import eos_tokens
 from convlab2.dialog_agent import Agent
 
 DEFAULT_DIRECTORY = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-DEFAULT_ARCHIVE_FILE_URL = "https://convlab.blob.core.windows.net/convlab-2/damd_multiwoz_data.zip"
-DEFAULT_MODEL_URL = "https://convlab.blob.core.windows.net/convlab-2/damd_multiwoz.zip"
+DEFAULT_ARCHIVE_FILE_URL = "https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/damd_multiwoz_data.zip"
+DEFAULT_MODEL_URL = "https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/damd_multiwoz.zip"
 
 class Damd(Agent):
     def __init__(self,

--- a/convlab2/e2e/rnn_rollout/deal_or_not/README.md
+++ b/convlab2/e2e/rnn_rollout/deal_or_not/README.md
@@ -12,7 +12,7 @@ license when using the code and datasets.
 
 ## Data preparation
 To use this model, you have to first download the pre-trained models
-from [here](https://convlab.blob.core.windows.net/convlab-2/rnnrollout_dealornot.zip), and put the *.th
+from [here](https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/rnnrollout_dealornot.zip), and put the *.th
 files under ```convlab2/e2e/rnn_rullout/deal_or_not/configs```.
 
 ## Run the Model

--- a/convlab2/e2e/rnn_rollout/deal_or_not/model.py
+++ b/convlab2/e2e/rnn_rollout/deal_or_not/model.py
@@ -12,7 +12,7 @@ import shutil
 class DealornotAgent(RNNRolloutAgent):
     """The Rnn Rollout model for DealorNot dataset."""
     def __init__(self, name, args, sel_args, train=False, diverse=False, max_total_len=100,
-                 model_url='https://convlab.blob.core.windows.net/convlab-2/rnnrollout_dealornot.zip'):
+                 model_url='https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/rnnrollout_dealornot.zip'):
         self.config_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'configs')
 
         self.file_url = model_url
@@ -75,7 +75,7 @@ def get_context_generator(context_file):
 #             os.path.exists(os.path.join(config_path, 'selection_model_state_dict.th')):
 #         exit()
 #     models_dir = os.path.join(config_path, 'models')
-#     file_url = 'https://convlab.blob.core.windows.net/convlab-2/rnnrollout_dealornot.zip'
+#     file_url = 'https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/rnnrollout_dealornot.zip'
 #     cached_path(file_url, models_dir)
 #     files = os.listdir(models_dir)
 #     target_file = ''

--- a/convlab2/e2e/sequicity/camrest/README.md
+++ b/convlab2/e2e/sequicity/camrest/README.md
@@ -11,7 +11,7 @@ We adapt the code from [github](https://github.com/WING-NUS/sequicity) to work i
 
 ### Prepare data
 
-Download [data](https://convlab.blob.core.windows.net/convlab-2/sequicity_camrest_data.zip) and unzip here.
+Download [data](https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/sequicity_camrest_data.zip) and unzip here.
 
 ### Training with default parameters
 
@@ -36,7 +36,7 @@ $ python model.py -mode rl -model camrest -cfg camrest/configs/camrest.json
 
 ### Trained model
 
-Trained model can be download on [here](https://convlab.blob.core.windows.net/convlab-2/sequicity_camrest.zip). Place it under `output` dir.
+Trained model can be download on [here](https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/sequicity_camrest.zip). Place it under `output` dir.
 
 ### Predict
 

--- a/convlab2/e2e/sequicity/camrest/sequicity.py
+++ b/convlab2/e2e/sequicity/camrest/sequicity.py
@@ -25,8 +25,8 @@ from convlab2.dialog_agent import Agent
 # DEFAULT_CUDA_DEVICE = -1
 DEFAULT_DIRECTORY = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 DEFAULT_CONFIG_FILE = os.path.join(DEFAULT_DIRECTORY, "camrest/configs/camrest.json")
-DEFAULT_ARCHIVE_FILE_URL = "https://convlab.blob.core.windows.net/convlab-2/sequicity_camrest_data.zip"
-DEFAULT_MODEL_URL = "https://convlab.blob.core.windows.net/convlab-2/sequicity_camrest.zip"
+DEFAULT_ARCHIVE_FILE_URL = "https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/sequicity_camrest_data.zip"
+DEFAULT_MODEL_URL = "https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/sequicity_camrest.zip"
 
 
 def denormalize(uttr):
@@ -44,7 +44,7 @@ class Sequicity(Agent):
 
         Args:
             model_file (str):
-                trained model path or url. default="https://convlab.blob.core.windows.net/convlab-2/sequicity_camrest.zip"
+                trained model path or url. default="https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/sequicity_camrest.zip"
 
         Example:
             sequicity = Sequicity()

--- a/convlab2/e2e/sequicity/multiwoz/README.md
+++ b/convlab2/e2e/sequicity/multiwoz/README.md
@@ -11,7 +11,7 @@ We adapt the code from [github](https://github.com/WING-NUS/sequicity) to work i
 
 ### Prepare data
 
-Download [data](https://convlab.blob.core.windows.net/convlab-2/sequicity_multiwoz_data.zip) and unzip here.
+Download [data](https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/sequicity_multiwoz_data.zip) and unzip here.
 
 ### Training with default parameters
 
@@ -36,7 +36,7 @@ $ python model.py -mode rl -model multiwoz -cfg multiwoz/configs/multiwoz.json
 
 ### Trained model
 
-Trained model can be download on [here](https://convlab.blob.core.windows.net/convlab-2/sequicity_multiwoz.zip). Place it under `output` dir.
+Trained model can be download on [here](https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/sequicity_multiwoz.zip). Place it under `output` dir.
 
 ### Predict
 

--- a/convlab2/e2e/sequicity/multiwoz/sequicity.py
+++ b/convlab2/e2e/sequicity/multiwoz/sequicity.py
@@ -26,8 +26,8 @@ from convlab2.dialog_agent import Agent
 # DEFAULT_CUDA_DEVICE = -1
 DEFAULT_DIRECTORY = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 DEFAULT_CONFIG_FILE = os.path.join(DEFAULT_DIRECTORY, "multiwoz/configs/multiwoz.json")
-DEFAULT_ARCHIVE_FILE_URL = "https://convlab.blob.core.windows.net/convlab-2/sequicity_multiwoz_data.zip"
-DEFAULT_MODEL_URL = "https://convlab.blob.core.windows.net/convlab-2/sequicity_multiwoz.zip"
+DEFAULT_ARCHIVE_FILE_URL = "https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/sequicity_multiwoz_data.zip"
+DEFAULT_MODEL_URL = "https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/sequicity_multiwoz.zip"
 
 
 def denormalize(uttr):
@@ -46,7 +46,7 @@ class Sequicity(Agent):
 
         Args:
             model_file (str):
-                trained model path or url. default="https://convlab.blob.core.windows.net/convlab-2/sequicity_multiwoz.zip"
+                trained model path or url. default="https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/sequicity_multiwoz.zip"
 
         Example:
             sequicity = Sequicity()

--- a/convlab2/laug/Text_Paraphrasing/Text_Paraphrasing.py
+++ b/convlab2/laug/Text_Paraphrasing/Text_Paraphrasing.py
@@ -6,7 +6,7 @@ class Text_Paraphrasing:
         if dataset=='multiwoz':
             self.model=SCGPT()
         if dataset=='frames':
-            self.model=SCGPT(model_file='https://convlab.blob.core.windows.net/convlab-2/nlg-gpt-frames.zip')
+            self.model=SCGPT(model_file='https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/nlg-gpt-frames.zip')
         self.model.init_session()
     def aug(self,text,span_info):
         t=span2tuple(span_info)

--- a/convlab2/nlg/scgpt/multiwoz/scgpt.py
+++ b/convlab2/nlg/scgpt/multiwoz/scgpt.py
@@ -19,7 +19,7 @@ class SCGPT(NLG):
                  archive_file=DEFAULT_ARCHIVE_FILE,
                  use_cuda=True,
                  is_user=False,
-                 model_file='https://convlab.blob.core.windows.net/convlab-2/nlg-gpt-multiwoz.zip'):
+                 model_file='https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/nlg-gpt-multiwoz.zip'):
         model_dir = os.path.dirname(os.path.abspath(__file__))
         if not os.path.isfile(archive_file):
             archive_file = cached_path(model_file)

--- a/convlab2/nlg/sclstm/camrest/README.md
+++ b/convlab2/nlg/sclstm/camrest/README.md
@@ -11,7 +11,7 @@ The code derives from [github](https://github.com/andy194673/nlg-sclstm-multiwoz
 
 ### Prepare the data
 
-unzip [zip](https://convlab.blob.core.windows.net/convlab-2/nlg_sclstm_camrest.zip) here
+unzip [zip](https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/nlg_sclstm_camrest.zip) here
 
 ### Train
 

--- a/convlab2/nlg/sclstm/camrest/sc_lstm.py
+++ b/convlab2/nlg/sclstm/camrest/sc_lstm.py
@@ -43,7 +43,7 @@ class SCLSTM(NLG):
                  archive_file=DEFAULT_ARCHIVE_FILE, 
                  use_cuda=False,
                  is_user=False,
-                 model_file='https://convlab.blob.core.windows.net/convlab-2/nlg_sclstm_camrest.zip'):
+                 model_file='https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/nlg_sclstm_camrest.zip'):
 
         if not os.path.isfile(archive_file):
             if not model_file:

--- a/convlab2/nlg/sclstm/crosswoz/sc_lstm.py
+++ b/convlab2/nlg/sclstm/crosswoz/sc_lstm.py
@@ -45,7 +45,7 @@ class SCLSTM(NLG):
                  archive_file=DEFAULT_ARCHIVE_FILE,
                  use_cuda=False,
                  is_user=False,
-                 model_file='https://convlab.blob.core.windows.net/convlab-2/nlg_sclstm_crosswoz.zip'):
+                 model_file='https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/nlg_sclstm_crosswoz.zip'):
 
         if not os.path.isfile(archive_file):
             if not model_file:

--- a/convlab2/nlg/sclstm/multiwoz/README.md
+++ b/convlab2/nlg/sclstm/multiwoz/README.md
@@ -11,7 +11,7 @@ The code derives from [github](https://github.com/andy194673/nlg-sclstm-multiwoz
 
 ### Prepare the data
 
-unzip [zip](https://convlab.blob.core.windows.net/convlab-2/nlg_sclstm_multiwoz.zip) here
+unzip [zip](https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/nlg_sclstm_multiwoz.zip) here
 
 ### Train
 

--- a/convlab2/nlg/sclstm/multiwoz/sc_lstm.py
+++ b/convlab2/nlg/sclstm/multiwoz/sc_lstm.py
@@ -43,7 +43,7 @@ class SCLSTM(NLG):
                  archive_file=DEFAULT_ARCHIVE_FILE, 
                  use_cuda=False,
                  is_user=False,
-                 model_file='https://convlab.blob.core.windows.net/convlab-2/nlg_sclstm_multiwoz.zip'):
+                 model_file='https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/nlg_sclstm_multiwoz.zip'):
 
         if not os.path.isfile(archive_file):
             if not model_file:

--- a/convlab2/nlu/jointBERT/crosswoz/README.md
+++ b/convlab2/nlu/jointBERT/crosswoz/README.md
@@ -56,9 +56,9 @@ We have trained two models: one use context information (last 3 utterances)(`con
 
 Models can be download form:
 
-Without context: https://convlab.blob.core.windows.net/convlab-2/bert_crosswoz_all.zip
+Without context: https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/bert_crosswoz_all.zip
 
-With context: https://convlab.blob.core.windows.net/convlab-2/bert_crosswoz_all_context.zip
+With context: https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/bert_crosswoz_all_context.zip
 
 
 

--- a/convlab2/nlu/jointBERT/crosswoz/nlu.py
+++ b/convlab2/nlu/jointBERT/crosswoz/nlu.py
@@ -13,7 +13,7 @@ from convlab2.nlu.jointBERT.crosswoz.preprocess import preprocess
 
 class BERTNLU(NLU):
     def __init__(self, mode='all', config_file='crosswoz_all_context.json',
-                 model_file='https://convlab.blob.core.windows.net/convlab-2/bert_crosswoz_all_context.zip'):
+                 model_file='https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/bert_crosswoz_all_context.zip'):
         assert mode == 'usr' or mode == 'sys' or mode == 'all'
         config_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'configs/{}'.format(config_file))
         config = json.load(open(config_file))
@@ -77,5 +77,5 @@ class BERTNLU(NLU):
 
 if __name__ == '__main__':
     nlu = BERTNLU(mode='all', config_file='crosswoz_all_context.json',
-                  model_file='https://convlab.blob.core.windows.net/convlab-2/bert_crosswoz_all_context.zip')
+                  model_file='https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/bert_crosswoz_all_context.zip')
     print(nlu.predict("北京布提克精品酒店酒店是什么类型，有健身房吗？", ['你好，给我推荐一个评分是5分，价格在100-200元的酒店。', '推荐您去北京布提克精品酒店。']))

--- a/convlab2/nlu/jointBERT/multiwoz/README.md
+++ b/convlab2/nlu/jointBERT/multiwoz/README.md
@@ -56,9 +56,9 @@ We have trained two models: one use context information (`configs/multiwoz_all_c
 
 Models can be download form:
 
-Without context: https://convlab.blob.core.windows.net/convlab-2/bert_multiwoz_all.zip
+Without context: https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/bert_multiwoz_all.zip
 
-With context: https://convlab.blob.core.windows.net/convlab-2/bert_multiwoz_all_context.zip
+With context: https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/bert_multiwoz_all_context.zip
 
 
 

--- a/convlab2/nlu/jointBERT/multiwoz/nlu.py
+++ b/convlab2/nlu/jointBERT/multiwoz/nlu.py
@@ -16,7 +16,7 @@ from spacy.symbols import ORTH, LEMMA, POS
 
 class BERTNLU(NLU):
     def __init__(self, mode='all', config_file='multiwoz_all_context.json',
-                 model_file='https://convlab.blob.core.windows.net/convlab-2/bert_multiwoz_all_context.zip'):
+                 model_file='https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/bert_multiwoz_all_context.zip'):
         assert mode == 'usr' or mode == 'sys' or mode == 'all'
         self.mode = mode
         config_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'configs/{}'.format(config_file))
@@ -114,7 +114,7 @@ class BERTNLU(NLU):
 if __name__ == '__main__':
     text = "How about rosa's bed and breakfast ? Their postcode is cb22ha."
     nlu = BERTNLU(mode='sys', config_file='multiwoz_sys_context.json',
-                  model_file='https://convlab.blob.core.windows.net/convlab-2/bert_multiwoz_all_context.zip')
+                  model_file='https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/bert_multiwoz_all_context.zip')
     print(nlu.predict(text))
     # text = "I don't care about the Price of the restaurant.I don't care about the Price of the restaurant.I don't care about the Price of the restaurant.I don't care about the Price of the restaurant.I don't care about the Price of the restaurant.I don't care about the Price of the restaurant.I don't care about the Price of the restaurant.I don't care about the Price of the restaurant.I don't care about the Price of the restaurant.I don't care about the Price of the restaurant.I don't care about the Price of the restaurant.I don't care about the Price of the restaurant.I don't care about the Price of the restaurant.I don't care about the Price of the restaurant.I don't care about the Price of the restaurant.I don't care about the Price of the restaurant.I don't care about the Price of the restaurant.I don't care about the Price of the restaurant.I don't care about the Price of the restaurant."
     # print(nlu.predict(text))

--- a/convlab2/nlu/milu/multiwoz/nlu.py
+++ b/convlab2/nlu/milu/multiwoz/nlu.py
@@ -28,7 +28,7 @@ class MILU(NLU):
     def __init__(self,
                 archive_file=DEFAULT_ARCHIVE_FILE,
                 cuda_device=DEFAULT_CUDA_DEVICE,
-                model_file="https://convlab.blob.core.windows.net/convlab-2/new_milu(20200922)_multiwoz_all_context.tar.gz",
+                model_file="https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/new_milu(20200922)_multiwoz_all_context.tar.gz",
                 context_size=3):
         """ Constructor for NLU class. """
 
@@ -88,7 +88,7 @@ class MILU(NLU):
 
 
 if __name__ == "__main__":
-    nlu = MILU(model_file="https://convlab.blob.core.windows.net/convlab-2/milu.tar.gz")
+    nlu = MILU(model_file="https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/milu.tar.gz")
     test_contexts = [
         "SENT_END",
         "SENT_END",

--- a/convlab2/nlu/svm/camrest/README.md
+++ b/convlab2/nlu/svm/camrest/README.md
@@ -33,9 +33,9 @@ The model will be saved on `model/svm_camrest_[mode].pickle`. Also, it will be z
 
 Trained models can be download on: 
 
-- Trained on all data: [mode=all](https://convlab.blob.core.windows.net/convlab-2/svm_camrest_all.zip)
-- Trained on user utterances only: [mode=usr](https://convlab.blob.core.windows.net/convlab-2/svm_camrest_usr.zip)
-- Trained on system utterances only: [mode=sys](https://convlab.blob.core.windows.net/convlab-2/svm_multiwoz_usr.zip)
+- Trained on all data: [mode=all](https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/svm_camrest_all.zip)
+- Trained on user utterances only: [mode=usr](https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/svm_camrest_usr.zip)
+- Trained on system utterances only: [mode=sys](https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/svm_multiwoz_usr.zip)
 
 #### Evaluate
 

--- a/convlab2/nlu/svm/camrest/nlu.py
+++ b/convlab2/nlu/svm/camrest/nlu.py
@@ -4,9 +4,9 @@ For more information, please refer to ``convlab2/nlu/svm/camrest/README.md``
 
 Trained models can be download on:
 
-- https://convlab.blob.core.windows.net/convlab-2/svm_camrest_all.zip
-- https://convlab.blob.core.windows.net/convlab-2/svm_camrest_sys.zip
-- https://convlab.blob.core.windows.net/convlab-2/svm_camrest_usr.zip
+- https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/svm_camrest_all.zip
+- https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/svm_camrest_sys.zip
+- https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/svm_camrest_usr.zip
 
 Reference:
 
@@ -34,7 +34,7 @@ class SVMNLU(NLU):
             nlu = SVMNLU(mode='usr')
         """
         assert mode == 'usr' or mode == 'sys' or mode == 'all'
-        model_file = 'https://convlab.blob.core.windows.net/convlab-2/svm_camrest_{}.zip'.format(mode)
+        model_file = 'https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/svm_camrest_{}.zip'.format(mode)
         config_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'configs/camrest_{}.cfg'.format(mode))
         self.config = configparser.ConfigParser()
         self.config.read(config_file)

--- a/convlab2/nlu/svm/multiwoz/README.md
+++ b/convlab2/nlu/svm/multiwoz/README.md
@@ -33,9 +33,9 @@ The model will be saved on `model/svm_multiwoz_[mode].pickle`. Also, it will be 
 
 Trained models can be download on: 
 
-- Trained on all data: [mode=all](https://convlab.blob.core.windows.net/convlab-2/svm_multiwoz_all.zip)
-- Trained on user utterances only: [mode=usr](https://convlab.blob.core.windows.net/convlab-2/svm_multiwoz_usr.zip)
-- Trained on system utterances only: [mode=sys](https://convlab.blob.core.windows.net/convlab-2/svm_multiwoz_usr.zip)
+- Trained on all data: [mode=all](https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/svm_multiwoz_all.zip)
+- Trained on user utterances only: [mode=usr](https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/svm_multiwoz_usr.zip)
+- Trained on system utterances only: [mode=sys](https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/svm_multiwoz_usr.zip)
 
 #### Evaluate
 

--- a/convlab2/nlu/svm/multiwoz/nlu.py
+++ b/convlab2/nlu/svm/multiwoz/nlu.py
@@ -4,9 +4,9 @@ For more information, please refer to ``convlab2/nlu/svm/multiwoz/README.md``
 
 Trained models can be download on:
 
-- https://convlab.blob.core.windows.net/convlab-2/svm_multiwoz_all.zip
-- https://convlab.blob.core.windows.net/convlab-2/svm_multiwoz_sys.zip
-- https://convlab.blob.core.windows.net/convlab-2/svm_multiwoz_usr.zip
+- https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/svm_multiwoz_all.zip
+- https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/svm_multiwoz_sys.zip
+- https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/svm_multiwoz_usr.zip
 
 Reference:
 
@@ -34,7 +34,7 @@ class SVMNLU(NLU):
             nlu = SVMNLU(mode='all')
         """
         assert mode == 'usr' or mode == 'sys' or mode == 'all'
-        model_file = 'https://convlab.blob.core.windows.net/convlab-2/svm_multiwoz_{}.zip'.format(mode)
+        model_file = 'https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/svm_multiwoz_{}.zip'.format(mode)
         config_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'configs/multiwoz_{}.cfg'.format(mode))
         self.config = configparser.ConfigParser()
         self.config.read(config_file)

--- a/convlab2/policy/dqn/dqn.py
+++ b/convlab2/policy/dqn/dqn.py
@@ -181,7 +181,7 @@ class DQN(Policy):
     @classmethod
     def from_pretrained(cls,
                         archive_file="",
-                        model_file="https://convlab.blob.core.windows.net/convlab-2/dqn_policy_multiwoz.zip",
+                        model_file="https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/dqn_policy_multiwoz.zip",
                         is_train=False,
                         dataset='Multiwoz'):
         with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'config.json'), 'r') as f:

--- a/convlab2/policy/dqn/multiwoz/dqn_policy.py
+++ b/convlab2/policy/dqn/multiwoz/dqn_policy.py
@@ -7,7 +7,7 @@ class DQNPolicy(DQN):
                 is_train=False,
                 dataset="Multiwoz",
                 archive_file="",
-                model_file="https://convlab.blob.core.windows.net/convlab-2/dqn_policy_multiwoz.zip"):
+                model_file="https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/dqn_policy_multiwoz.zip"):
         super().__init__(is_train=is_train, dataset=dataset)
         with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'config.json'), 'r') as f:
             cfg = json.load(f)

--- a/convlab2/policy/gdpl/gdpl.py
+++ b/convlab2/policy/gdpl/gdpl.py
@@ -253,7 +253,7 @@ class GDPL(Policy):
     @classmethod
     def from_pretrained(cls,
                         archive_file="",
-                        model_file="https://convlab.blob.core.windows.net/convlab-2/gdpl_policy_multiwoz.zip",
+                        model_file="https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/gdpl_policy_multiwoz.zip",
                         is_train=False,
                         dataset='Multiwoz'):
         with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'config.json'), 'r') as f:

--- a/convlab2/policy/gdpl/multiwoz/README.md
+++ b/convlab2/policy/gdpl/multiwoz/README.md
@@ -32,7 +32,7 @@ Performance:
 
 The model can be downloaded from: 
 
-https://convlab.blob.core.windows.net/convlab-2/gdpl_policy_multiwoz.zip
+https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/gdpl_policy_multiwoz.zip
 
 ## Reference
 

--- a/convlab2/policy/gdpl/multiwoz/gdpl_policy.py
+++ b/convlab2/policy/gdpl/multiwoz/gdpl_policy.py
@@ -7,7 +7,7 @@ class GDPLPolicy(GDPL):
                  is_train=False,
                  dataset='Multiwoz',
                  archive_file="",
-                 model_file="https://convlab.blob.core.windows.net/convlab-2/gdpl_policy_multiwoz.zip"):
+                 model_file="https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/gdpl_policy_multiwoz.zip"):
         super().__init__(is_train=is_train, dataset=dataset)
         with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'config.json'), 'r') as f:
             cfg = json.load(f)

--- a/convlab2/policy/hdsa/multiwoz/hdsa.py
+++ b/convlab2/policy/hdsa/multiwoz/hdsa.py
@@ -10,7 +10,7 @@ DEFAULT_ARCHIVE_FILE = os.path.join(DEFAULT_DIRECTORY, "hdsa.zip")
 
 class HDSA(Policy):
 
-    def __init__(self, archive_file=DEFAULT_ARCHIVE_FILE, model_file="https://convlab.blob.core.windows.net/convlab-2/hdsa.zip", use_cuda=False):
+    def __init__(self, archive_file=DEFAULT_ARCHIVE_FILE, model_file="https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/hdsa.zip", use_cuda=False):
         self.predictor = HDSA_predictor(archive_file, model_file, use_cuda)
         self.generator = HDSA_generator(archive_file, model_file, use_cuda)
 

--- a/convlab2/policy/larl/multiwoz/larl.py
+++ b/convlab2/policy/larl/multiwoz/larl.py
@@ -238,7 +238,7 @@ class LaRL(Policy):
     def __init__(self,
                  archive_file=DEFAULT_ARCHIVE_FILE,
                  cuda_device=DEFAULT_CUDA_DEVICE,
-                 model_file="https://convlab.blob.core.windows.net/convlab-2/larl.zip"):
+                 model_file="https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/larl.zip"):
 
         if not os.path.isfile(archive_file):
             if not model_file:

--- a/convlab2/policy/mdrg/multiwoz/auto_download.py
+++ b/convlab2/policy/mdrg/multiwoz/auto_download.py
@@ -11,9 +11,9 @@ def auto_download():
     db_path = os.path.join(os.path.dirname(__file__), 'db')
     root_path = os.path.dirname(__file__)
 
-    urls = {model_path: 'https://convlab.blob.core.windows.net/convlab-2/mdrg_model.zip',
-            data_path: 'https://convlab.blob.core.windows.net/convlab-2/mdrg_data.zip',
-            db_path: 'https://convlab.blob.core.windows.net/convlab-2/mdrg_db.zip'}
+    urls = {model_path: 'https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/mdrg_model.zip',
+            data_path: 'https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/mdrg_data.zip',
+            db_path: 'https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/mdrg_db.zip'}
 
     for path in [model_path, data_path, db_path]:
         if not os.path.exists(path):

--- a/convlab2/policy/mdrg/multiwoz/utils/dbPointer.py
+++ b/convlab2/policy/mdrg/multiwoz/utils/dbPointer.py
@@ -13,9 +13,9 @@ def auto_download():
     db_path = os.path.join(os.path.dirname(__file__), os.pardir, 'db')
     root_path = os.path.join(os.path.dirname(__file__), os.pardir)
 
-    urls = {model_path: 'https://convlab.blob.core.windows.net/convlab-2/mdrg_model.zip',
-            data_path: 'https://convlab.blob.core.windows.net/convlab-2/mdrg_data.zip',
-            db_path: 'https://convlab.blob.core.windows.net/convlab-2/mdrg_db.zip'}
+    urls = {model_path: 'https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/mdrg_model.zip',
+            data_path: 'https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/mdrg_data.zip',
+            db_path: 'https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/mdrg_db.zip'}
 
     for path in [model_path, data_path, db_path]:
         if not os.path.exists(path):

--- a/convlab2/policy/mdrg/multiwoz/utils/dbquery.py
+++ b/convlab2/policy/mdrg/multiwoz/utils/dbquery.py
@@ -11,9 +11,9 @@ def auto_download():
     db_path = os.path.join(os.path.dirname(__file__), os.pardir, 'db')
     root_path = os.path.join(os.path.dirname(__file__), os.pardir)
 
-    urls = {model_path: 'https://convlab.blob.core.windows.net/convlab-2/mdrg_model.zip',
-            data_path: 'https://convlab.blob.core.windows.net/convlab-2/mdrg_data.zip',
-            db_path: 'https://convlab.blob.core.windows.net/convlab-2/mdrg_db.zip'}
+    urls = {model_path: 'https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/mdrg_model.zip',
+            data_path: 'https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/mdrg_data.zip',
+            db_path: 'https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/mdrg_db.zip'}
 
     for path in [model_path, data_path, db_path]:
         if not os.path.exists(path):

--- a/convlab2/policy/mle/camrest/mle.py
+++ b/convlab2/policy/mle/camrest/mle.py
@@ -15,7 +15,7 @@ class MLE(MLEAbstract):
     
     def __init__(self,
                  archive_file=DEFAULT_ARCHIVE_FILE,
-                 model_file='https://convlab.blob.core.windows.net/convlab-2/mle_policy_camrest.zip'):
+                 model_file='https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/mle_policy_camrest.zip'):
         root_dir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))))
         
         with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'config.json'), 'r') as f:

--- a/convlab2/policy/mle/crosswoz/mle.py
+++ b/convlab2/policy/mle/crosswoz/mle.py
@@ -18,7 +18,7 @@ class MLE(MLEAbstract):
 
     def __init__(self,
                  archive_file=DEFAULT_ARCHIVE_FILE,
-                 model_file='https://convlab.blob.core.windows.net/convlab-2/mle_policy_crosswoz.zip'):
+                 model_file='https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/mle_policy_crosswoz.zip'):
         root_dir = os.path.dirname(
             os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))))
 

--- a/convlab2/policy/mle/multiwoz/README.md
+++ b/convlab2/policy/mle/multiwoz/README.md
@@ -24,4 +24,4 @@ Performance:
 
 The model can be downloaded from: 
 
-https://convlab.blob.core.windows.net/convlab-2/mle_policy_multiwoz.zip
+https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/mle_policy_multiwoz.zip

--- a/convlab2/policy/mle/multiwoz/mle.py
+++ b/convlab2/policy/mle/multiwoz/mle.py
@@ -28,7 +28,7 @@ class MLE(MLEAbstract):
     @classmethod
     def from_pretrained(cls,
                         archive_file=DEFAULT_ARCHIVE_FILE,
-                        model_file='https://convlab.blob.core.windows.net/convlab-2/mle_policy_multiwoz.zip'):
+                        model_file='https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/mle_policy_multiwoz.zip'):
         with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'config.json'), 'r') as f:
             cfg = json.load(f)
         model = cls()
@@ -38,7 +38,7 @@ class MLE(MLEAbstract):
 class MLEPolicy(MLE):
     def __init__(self,
                  archive_file=DEFAULT_ARCHIVE_FILE,
-                 model_file='https://convlab.blob.core.windows.net/convlab-2/mle_policy_multiwoz.zip'):
+                 model_file='https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/mle_policy_multiwoz.zip'):
         super().__init__()
         if model_file:
             with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'config.json'), 'r') as f:

--- a/convlab2/policy/pg/multiwoz/README.md
+++ b/convlab2/policy/pg/multiwoz/README.md
@@ -30,7 +30,7 @@ Performance:
 
 The model can be downloaded from: 
 
-https://convlab.blob.core.windows.net/convlab-2/pg_policy_multiwoz.zip
+https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/pg_policy_multiwoz.zip
 
 ## Reference
 

--- a/convlab2/policy/pg/multiwoz/pg_policy.py
+++ b/convlab2/policy/pg/multiwoz/pg_policy.py
@@ -4,7 +4,7 @@ import json
 
 class PGPolicy(PG):
     def __init__(self, is_train=False, dataset='Multiwoz', archive_file="",
-                        model_file="https://convlab.blob.core.windows.net/convlab-2/pg_policy_multiwoz.zip"):
+                        model_file="https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/pg_policy_multiwoz.zip"):
         super().__init__(is_train=is_train, dataset=dataset)
         with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'config.json'), 'r') as f:
             cfg = json.load(f)

--- a/convlab2/policy/pg/pg.py
+++ b/convlab2/policy/pg/pg.py
@@ -183,7 +183,7 @@ class PG(Policy):
     @classmethod
     def from_pretrained(cls,
                         archive_file="",
-                        model_file="https://convlab.blob.core.windows.net/convlab-2/pg_policy_multiwoz.zip"):
+                        model_file="https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/pg_policy_multiwoz.zip"):
         with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'config.json'), 'r') as f:
             cfg = json.load(f)
         model = cls()

--- a/convlab2/policy/ppo/multiwoz/README.md
+++ b/convlab2/policy/ppo/multiwoz/README.md
@@ -32,7 +32,7 @@ Performance:
 
 The model can be downloaded from: 
 
-https://convlab.blob.core.windows.net/convlab-2/ppo_policy_multiwoz.zip
+https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/ppo_policy_multiwoz.zip
 
 ## Reference
 

--- a/convlab2/policy/ppo/multiwoz/ppo_policy.py
+++ b/convlab2/policy/ppo/multiwoz/ppo_policy.py
@@ -6,7 +6,7 @@ class PPOPolicy(PPO):
     def __init__(self,  is_train=False, 
                         dataset='Multiwoz', 
                         archive_file="",
-                        model_file="https://convlab.blob.core.windows.net/convlab-2/ppo_policy_multiwoz.zip"
+                        model_file="https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/ppo_policy_multiwoz.zip"
                         ):
         super().__init__(is_train=is_train, dataset=dataset)
         with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'config.json'), 'r') as f:

--- a/convlab2/policy/ppo/ppo.py
+++ b/convlab2/policy/ppo/ppo.py
@@ -254,7 +254,7 @@ class PPO(Policy):
     @classmethod
     def from_pretrained(cls,
                         archive_file="",
-                        model_file="https://convlab.blob.core.windows.net/convlab-2/ppo_policy_multiwoz.zip",
+                        model_file="https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/ppo_policy_multiwoz.zip",
                         is_train=False,
                         dataset='Multiwoz'):
         with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'config.json'), 'r') as f:

--- a/convlab2/policy/rule/multiwoz/policy_agenda_multiwoz.py
+++ b/convlab2/policy/rule/multiwoz/policy_agenda_multiwoz.py
@@ -930,7 +930,7 @@ if __name__ == '__main__':
     # sys_agent = PipelineAgent(sys_nlu, sys_dst, sys_policy, sys_nlg, name='sys')
 
     # user_nlu = BERTNLU(mode='sys', config_file='multiwoz_sys_context.json',
-    #                    model_file='https://convlab.blob.core.windows.net/convlab-2/bert_multiwoz_sys_context.zip')
+    #                    model_file='https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/bert_multiwoz_sys_context.zip')
     # user_dst = None
     # user_policy = RulePolicy(character='usr')
     # user_nlg = TemplateNLG(is_user=True)
@@ -952,7 +952,7 @@ if __name__ == '__main__':
     dst = RuleDST()
     #
     # user_nlu = BERTNLU(mode='sys', config_file='multiwoz_sys_context.json',
-    #                    model_file='https://convlab.blob.core.windows.net/convlab-2/bert_multiwoz_sys_context.zip')
+    #                    model_file='https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/bert_multiwoz_sys_context.zip')
     #
     goal_generator = GoalGenerator()
     # while True:

--- a/convlab2/policy/vhus/camrest/vhus.py
+++ b/convlab2/policy/vhus/camrest/vhus.py
@@ -16,7 +16,7 @@ class UserPolicyVHUS(UserPolicyVHUSAbstract):
 
     def __init__(self,
                  archive_file=DEFAULT_ARCHIVE_FILE,
-                 model_file='https://convlab.blob.core.windows.net/convlab-2/vhus_simulator_camrest.zip'):
+                 model_file='https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/vhus_simulator_camrest.zip'):
         with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'config.json'), 'r') as f:
             config = json.load(f)
         manager = UserDataManager()

--- a/convlab2/policy/vhus/multiwoz/README.md
+++ b/convlab2/policy/vhus/multiwoz/README.md
@@ -31,7 +31,7 @@ Performance:
 
 The model can be downloaded from: 
 
-https://convlab.blob.core.windows.net/convlab-2/vhus_simulator_multiwoz.zip
+https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/vhus_simulator_multiwoz.zip
 
 ## Reference
 

--- a/convlab2/policy/vhus/multiwoz/vhus.py
+++ b/convlab2/policy/vhus/multiwoz/vhus.py
@@ -18,7 +18,7 @@ class UserPolicyVHUS(UserPolicyVHUSAbstract):
     def __init__(self,
                  load_from_zip=False,
                  archive_file=DEFAULT_ARCHIVE_FILE,
-                 model_file='https://convlab.blob.core.windows.net/convlab-2/vhus_simulator_multiwoz.zip'):
+                 model_file='https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/vhus_simulator_multiwoz.zip'):
         with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'config.json'), 'r') as f:
             config = json.load(f)
         manager = UserDataManager()

--- a/deploy/dep_config.json
+++ b/deploy/dep_config.json
@@ -33,7 +33,7 @@
       "ini_params": {
         "mode": "all",
         "config_file": "crosswoz_all.json",
-        "model_file": "https://convlab.blob.core.windows.net/convlab-2/bert_crosswoz_all.zip"
+        "model_file": "https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/bert_crosswoz_all.zip"
       },
       "model_name": "bert-cro",
       "max_core": 1,
@@ -46,7 +46,7 @@
       "ini_params": {
         "mode": "all",
         "config_file": "multiwoz_all.json",
-        "model_file": "https://convlab.blob.core.windows.net/convlab-2/bert_multiwoz_all.zip"
+        "model_file": "https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/bert_multiwoz_all.zip"
       },
       "model_name": "bert-mul",
       "max_core": 1,

--- a/tests/test_BERTNLU-RuleDST-DQNPolicy-TemplateNLG.py
+++ b/tests/test_BERTNLU-RuleDST-DQNPolicy-TemplateNLG.py
@@ -54,7 +54,7 @@ def test_end2end():
 
     # BERT nlu trained on sys utterance
     user_nlu = BERTNLU(mode='sys', config_file='multiwoz_sys_context.json',
-                       model_file='https://convlab.blob.core.windows.net/convlab-2/bert_multiwoz_sys_context.zip')
+                       model_file='https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/bert_multiwoz_sys_context.zip')
     # not use dst
     user_dst = None
     # rule policy

--- a/tests/test_BERTNLU-RuleDST-GDPLPolicy-TemplateNLG.py
+++ b/tests/test_BERTNLU-RuleDST-GDPLPolicy-TemplateNLG.py
@@ -54,7 +54,7 @@ def test_end2end():
 
     # BERT nlu trained on sys utterance
     user_nlu = BERTNLU(mode='sys', config_file='multiwoz_sys_context.json',
-                       model_file='https://convlab.blob.core.windows.net/convlab-2/bert_multiwoz_sys_context.zip')
+                       model_file='https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/bert_multiwoz_sys_context.zip')
     # not use dst
     user_dst = None
     # rule policy

--- a/tests/test_BERTNLU-RuleDST-HDSA.py
+++ b/tests/test_BERTNLU-RuleDST-HDSA.py
@@ -54,7 +54,7 @@ def test_end2end():
 
     # BERT nlu trained on sys utterance
     user_nlu = BERTNLU(mode='sys', config_file='multiwoz_sys_context.json',
-                       model_file='https://convlab.blob.core.windows.net/convlab-2/bert_multiwoz_sys_context.zip')
+                       model_file='https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/bert_multiwoz_sys_context.zip')
     # not use dst
     user_dst = None
     # rule policy

--- a/tests/test_BERTNLU-RuleDST-LaRL.py
+++ b/tests/test_BERTNLU-RuleDST-LaRL.py
@@ -54,7 +54,7 @@ def test_end2end():
 
     # BERT nlu trained on sys utterance
     user_nlu = BERTNLU(mode='sys', config_file='multiwoz_sys_context.json',
-                       model_file='https://convlab.blob.core.windows.net/convlab-2/bert_multiwoz_sys_context.zip')
+                       model_file='https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/bert_multiwoz_sys_context.zip')
     # not use dst
     user_dst = None
     # rule policy

--- a/tests/test_BERTNLU-RuleDST-MDRG.py
+++ b/tests/test_BERTNLU-RuleDST-MDRG.py
@@ -54,7 +54,7 @@ def test_end2end():
 
     # BERT nlu trained on sys utterance
     user_nlu = BERTNLU(mode='sys', config_file='multiwoz_sys_context.json',
-                       model_file='https://convlab.blob.core.windows.net/convlab-2/bert_multiwoz_sys_context.zip')
+                       model_file='https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/bert_multiwoz_sys_context.zip')
     # not use dst
     user_dst = None
     # rule policy

--- a/tests/test_BERTNLU-RuleDST-MLEPolicy-TemplateNLG.py
+++ b/tests/test_BERTNLU-RuleDST-MLEPolicy-TemplateNLG.py
@@ -54,7 +54,7 @@ def test_end2end():
 
     # BERT nlu trained on sys utterance
     user_nlu = BERTNLU(mode='sys', config_file='multiwoz_sys_context.json',
-                       model_file='https://convlab.blob.core.windows.net/convlab-2/bert_multiwoz_sys_context.zip')
+                       model_file='https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/bert_multiwoz_sys_context.zip')
     # not use dst
     user_dst = None
     # rule policy

--- a/tests/test_BERTNLU-RuleDST-PGPolicy-TemplateNLG.py
+++ b/tests/test_BERTNLU-RuleDST-PGPolicy-TemplateNLG.py
@@ -54,7 +54,7 @@ def test_end2end():
 
     # BERT nlu trained on sys utterance
     user_nlu = BERTNLU(mode='sys', config_file='multiwoz_sys_context.json',
-                       model_file='https://convlab.blob.core.windows.net/convlab-2/bert_multiwoz_sys_context.zip')
+                       model_file='https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/bert_multiwoz_sys_context.zip')
     # not use dst
     user_dst = None
     # rule policy

--- a/tests/test_BERTNLU-RuleDST-PPOPolicy-TemplateNLG.py
+++ b/tests/test_BERTNLU-RuleDST-PPOPolicy-TemplateNLG.py
@@ -54,7 +54,7 @@ def test_end2end():
 
     # BERT nlu trained on sys utterance
     user_nlu = BERTNLU(mode='sys', config_file='multiwoz_sys_context.json',
-                       model_file='https://convlab.blob.core.windows.net/convlab-2/bert_multiwoz_sys_context.zip')
+                       model_file='https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/bert_multiwoz_sys_context.zip')
     # not use dst
     user_dst = None
     # rule policy

--- a/tests/test_BERTNLU-RuleDST-RulePolicy-SCLSTM.py
+++ b/tests/test_BERTNLU-RuleDST-RulePolicy-SCLSTM.py
@@ -54,7 +54,7 @@ def test_end2end():
 
     # BERT nlu trained on sys utterance
     user_nlu = BERTNLU(mode='sys', config_file='multiwoz_sys_context.json',
-                       model_file='https://convlab.blob.core.windows.net/convlab-2/bert_multiwoz_sys_context.zip')
+                       model_file='https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/bert_multiwoz_sys_context.zip')
     # not use dst
     user_dst = None
     # rule policy

--- a/tests/test_BERTNLU-RuleDST-RulePolicy-TemplateNLG.py
+++ b/tests/test_BERTNLU-RuleDST-RulePolicy-TemplateNLG.py
@@ -54,7 +54,7 @@ def test_end2end():
 
     # BERT nlu trained on sys utterance
     user_nlu = BERTNLU(mode='sys', config_file='multiwoz_sys_context.json',
-                       model_file='https://convlab.blob.core.windows.net/convlab-2/bert_multiwoz_sys_context.zip')
+                       model_file='https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/bert_multiwoz_sys_context.zip')
     # not use dst
     user_dst = None
     # rule policy

--- a/tests/test_COMER_RulePolicy_TemplateNLG.py
+++ b/tests/test_COMER_RulePolicy_TemplateNLG.py
@@ -57,7 +57,7 @@ def test_end2end():
 
     # BERT nlu trained on sys utterance
     user_nlu = BERTNLU(mode='sys', config_file='multiwoz_sys_context.json',
-                       model_file='https://convlab.blob.core.windows.net/convlab-2/bert_multiwoz_sys_context.zip')
+                       model_file='https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/bert_multiwoz_sys_context.zip')
     # not use dst
     user_dst = None
     # rule policy

--- a/tests/test_DAMD.py
+++ b/tests/test_DAMD.py
@@ -55,7 +55,7 @@ def test_end2end():
 
     # BERT nlu trained on sys utterance
     user_nlu = BERTNLU(mode='sys', config_file='multiwoz_sys_context.json',
-                       model_file='https://convlab.blob.core.windows.net/convlab-2/bert_multiwoz_sys_context.zip')
+                       model_file='https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/bert_multiwoz_sys_context.zip')
     # not use dst
     user_dst = None
     # rule policy

--- a/tests/test_MDBT_RulePolicy_TemplateNLG.py
+++ b/tests/test_MDBT_RulePolicy_TemplateNLG.py
@@ -55,7 +55,7 @@ def test_end2end():
 
     # BERT nlu trained on sys utterance
     user_nlu = BERTNLU(mode='sys', config_file='multiwoz_sys_context.json',
-                       model_file='https://convlab.blob.core.windows.net/convlab-2/bert_multiwoz_sys_context.zip')
+                       model_file='https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/bert_multiwoz_sys_context.zip')
     # not use dst
     user_dst = None
     # rule policy

--- a/tests/test_MILU-RuleDST-RulePolicy-TemplateNLG.py
+++ b/tests/test_MILU-RuleDST-RulePolicy-TemplateNLG.py
@@ -54,7 +54,7 @@ def test_end2end():
 
     # BERT nlu trained on sys utterance
     user_nlu = BERTNLU(mode='sys', config_file='multiwoz_sys_context.json',
-                       model_file='https://convlab.blob.core.windows.net/convlab-2/bert_multiwoz_sys_context.zip')
+                       model_file='https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/bert_multiwoz_sys_context.zip')
     # not use dst
     user_dst = None
     # rule policy

--- a/tests/test_SUMBT-LaRL.py
+++ b/tests/test_SUMBT-LaRL.py
@@ -54,7 +54,7 @@ def test_end2end():
 
     # BERT nlu trained on sys utterance
     user_nlu = BERTNLU(mode='sys', config_file='multiwoz_sys_context.json',
-                       model_file='https://convlab.blob.core.windows.net/convlab-2/bert_multiwoz_sys_context.zip')
+                       model_file='https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/bert_multiwoz_sys_context.zip')
     # not use dst
     user_dst = None
     # rule policy

--- a/tests/test_SUMBT-RulePolicy-TemplateNLG.py
+++ b/tests/test_SUMBT-RulePolicy-TemplateNLG.py
@@ -55,7 +55,7 @@ def test_end2end():
 
     # BERT nlu trained on sys utterance
     user_nlu = BERTNLU(mode='sys', config_file='multiwoz_sys_context.json',
-                       model_file='https://convlab.blob.core.windows.net/convlab-2/bert_multiwoz_sys_context.zip')
+                       model_file='https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/bert_multiwoz_sys_context.zip')
     # not use dst
     user_dst = None
     # rule policy

--- a/tests/test_SVMNLU-RuleDST-RulePolicy-TemplateNLG.py
+++ b/tests/test_SVMNLU-RuleDST-RulePolicy-TemplateNLG.py
@@ -54,7 +54,7 @@ def test_end2end():
 
     # BERT nlu trained on sys utterance
     user_nlu = BERTNLU(mode='sys', config_file='multiwoz_sys_context.json',
-                       model_file='https://convlab.blob.core.windows.net/convlab-2/bert_multiwoz_sys_context.zip')
+                       model_file='https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/bert_multiwoz_sys_context.zip')
     # not use dst
     user_dst = None
     # rule policy

--- a/tests/test_Sequicity.py
+++ b/tests/test_Sequicity.py
@@ -55,7 +55,7 @@ def test_end2end():
 
     # BERT nlu trained on sys utterance
     user_nlu = BERTNLU(mode='sys', config_file='multiwoz_sys_context.json',
-                       model_file='https://convlab.blob.core.windows.net/convlab-2/bert_multiwoz_sys_context.zip')
+                       model_file='https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/bert_multiwoz_sys_context.zip')
     # not use dst
     user_dst = None
     # rule policy

--- a/tests/test_TRADE_RulePolicy_TemplateNLG.py
+++ b/tests/test_TRADE_RulePolicy_TemplateNLG.py
@@ -55,7 +55,7 @@ def test_end2end():
 
     # BERT nlu trained on sys utterance
     user_nlu = BERTNLU(mode='sys', config_file='multiwoz_sys_context.json',
-                       model_file='https://convlab.blob.core.windows.net/convlab-2/bert_multiwoz_sys_context.zip')
+                       model_file='https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/bert_multiwoz_sys_context.zip')
     # not use dst
     user_dst = None
     # rule policy

--- a/tests/test_end2end.py
+++ b/tests/test_end2end.py
@@ -54,7 +54,7 @@ def test_end2end():
 
     # BERT nlu trained on sys utterance
     user_nlu = BERTNLU(mode='sys', config_file='multiwoz_sys_context.json',
-                       model_file='https://convlab.blob.core.windows.net/convlab-2/bert_multiwoz_sys_context.zip')
+                       model_file='https://huggingface.co/ConvLab/ConvLab-2_models/resolve/main/bert_multiwoz_sys_context.zip')
     # not use dst
     user_dst = None
     # rule policy


### PR DESCRIPTION
**Description:**

Due to the potential security risk, The trained models of ConvLab-2 hosted at Azure can not be accessed currently. Therefore, we copied these models and placed them in [Hugging Face](https://huggingface.co/ConvLab/ConvLab-2_models). We've replaced the model URL in the ConvLab-2 code with the model URL in our Hugging Face repo. If you try to use trained models of ConvLab-2, make sure to update the code.

**Reference Issues:** #239 (XX is the issue number you work on)
